### PR TITLE
Change branch instruction in CH10 move_enemies proc

### DIFF
--- a/CH10/megablast.s
+++ b/CH10/megablast.s
@@ -431,7 +431,7 @@ mainloop:
 	lda #0
 @loop:
 	lda enemydata,y
-	beq :+
+	bne :+
 		jmp @skip
 	:
 


### PR DESCRIPTION
The current branch instruction will prevent the move_enemies procedure from completing correctly. The instruction is correct in CH11, but CH10 is not playable when compiled.

Expected: enemies to advance towards bottom of screen
Actual: enemies do not advance

To reproduce: compile and run megablast.nes in CH10 from the main branch
To verify fix: compile and run megablast.nes in CH10 from this branch