### PR TITLE
Prevent score underflow when asteroid hit with 97 score

### DIFF
--- a/CH10/megablast.s
+++ b/CH10/megablast.s
@@ -545,7 +545,7 @@ mainloop:
 	clc
 	adc score ; add the value in a to the 1st byte of the score
 	sta score
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 1st byte has exceeded 99, handle overflow
@@ -553,7 +553,7 @@ mainloop:
 	sta score
 	inc score+1
 	lda score+1
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 2nd byte has exceeded 99, handle overflow
@@ -561,7 +561,7 @@ mainloop:
 	sta score+1
 	inc score+2
 	lda score+2
-	cmp #99
+	cmp #100
 	bcc @skip
 	sec ; if 3rd byte has exceeded 99, adjust and discard overflow
 	sbc #100

--- a/CH11/megablast.s
+++ b/CH11/megablast.s
@@ -674,7 +674,7 @@ mainloop:
 	clc
 	adc score ; add the value in a to the 1st byte of the score
 	sta score
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 1st byte has exceeded 99, handle overflow
@@ -682,7 +682,7 @@ mainloop:
 	sta score
 	inc score+1
 	lda score+1
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 2nd byte has exceeded 99, handle overflow
@@ -690,7 +690,7 @@ mainloop:
 	sta score+1
 	inc score+2
 	lda score+2
-	cmp #99
+	cmp #100
 	bcc @skip
 	sec ; if 3rd byte has exceeded 99, adjust and discard overflow
 	sbc #100

--- a/CH12/megablast.s
+++ b/CH12/megablast.s
@@ -841,7 +841,7 @@ mainloop:
 	clc
 	adc score ; add the value in a to the 1st byte of the score
 	sta score
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 1st byte has exceeded 99, handle overflow
@@ -849,7 +849,7 @@ mainloop:
 	sta score
 	inc score+1
 	lda score+1
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 2nd byte has exceeded 99, handle overflow
@@ -857,7 +857,7 @@ mainloop:
 	sta score+1
 	inc score+2
 	lda score+2
-	cmp #99
+	cmp #100
 	bcc @skip
 	sec ; if 3rd byte has exceeded 99, adjust and discard overflow
 	sbc #100

--- a/CH13/megablast.s
+++ b/CH13/megablast.s
@@ -1110,7 +1110,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	clc
 	adc score ; add the value in a to the 1st byte of the score
 	sta score
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 1st byte has exceeded 99, handle overflow
@@ -1118,7 +1118,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	sta score
 	inc score+1
 	lda score+1
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 2nd byte has exceeded 99, handle overflow
@@ -1126,7 +1126,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	sta score+1
 	inc score+2
 	lda score+2
-	cmp #99
+	cmp #100
 	bcc @skip
 	sec ; if 3rd byte has exceeded 99, adjust and discard overflow
 	sbc #100

--- a/CH14/megablast.s
+++ b/CH14/megablast.s
@@ -1199,7 +1199,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	clc
 	adc score ; add the value in a to the 1st byte of the score
 	sta score
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 1st byte has exceeded 99, handle overflow
@@ -1207,7 +1207,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	sta score
 	inc score+1
 	lda score+1
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 2nd byte has exceeded 99, handle overflow
@@ -1215,7 +1215,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	sta score+1
 	inc score+2
 	lda score+2
-	cmp #99
+	cmp #100
 	bcc @skip
 	sec ; if 3rd byte has exceeded 99, adjust and discard overflow
 	sbc #100

--- a/CH15/megablast.s
+++ b/CH15/megablast.s
@@ -1232,7 +1232,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	clc
 	adc score ; add the value in a to the 1st byte of the score
 	sta score
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 1st byte has exceeded 99, handle overflow
@@ -1240,7 +1240,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	sta score
 	inc score+1
 	lda score+1
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 2nd byte has exceeded 99, handle overflow
@@ -1248,7 +1248,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	sta score+1
 	inc score+2
 	lda score+2
-	cmp #99
+	cmp #100
 	bcc @skip
 	sec ; if 3rd byte has exceeded 99, adjust and discard overflow
 	sbc #100

--- a/CH16/megablast.s
+++ b/CH16/megablast.s
@@ -1235,7 +1235,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	clc
 	adc score ; add the value in a to the 1st byte of the score
 	sta score
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 1st byte has exceeded 99, handle overflow
@@ -1243,7 +1243,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	sta score
 	inc score+1
 	lda score+1
-	cmp #99
+	cmp #100
 	bcc @skip
 
 	sec ; 2nd byte has exceeded 99, handle overflow
@@ -1251,7 +1251,7 @@ starlocations:	.res 10*2 ; two bytes per star
 	sta score+1
 	inc score+2
 	lda score+2
-	cmp #99
+	cmp #100
 	bcc @skip
 	sec ; if 3rd byte has exceeded 99, adjust and discard overflow
 	sbc #100


### PR DESCRIPTION
Score memory value is $FF, when A register equals 99 following the adc score with 2, and 100 is subtracted. The compare is setting the carry flag when the values are equal, when it should be clear. This change bumps the compare to 100 so that values less than or equal to 99 will result in a clear carry flag.

Expected behavior: shooting an asteroid at 970 sets the score to 990
Actual behavior: shooting an asteroid at 970 bumps the score to 1150 and then changes to the score go into undefined behavior

To reproduce: achieve score of 970 in compiled megablast.nes on main branch any chapter starting at CH10 and shoot an asteroid, see incorrect score
To verify fix: achieve score of 970 in compiled megablast.nes on this branch any chapter starting at CH10 and shoot an asteroid, see correct score

**Values before**

![before-underflow](https://github.com/tony-cruise/ProgrammingGamesForTheNES/assets/56495871/deed7fa5-d075-442e-ac48-c6c77a1da548)

**Debugger showing that we advanced past bcc branching**

![should-have-branched](https://github.com/tony-cruise/ProgrammingGamesForTheNES/assets/56495871/8d493203-ae4c-41ca-812c-699757bc25c4)

**Value of FF in A register before storing in score first byte**

![underflow](https://github.com/tony-cruise/ProgrammingGamesForTheNES/assets/56495871/d5b52999-14e9-4333-a18d-460aebad4726)

